### PR TITLE
Post entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .idea/
+.*.swp

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ enablePlugins(JavaAppPackaging)
 
 name := "akka-request"
 organization := "io.dronekit"
-version := "2.2.1"
+version := "2.2.2"
 scalaVersion := "2.11.7"
 
 resolvers += "Artifactory" at "https://dronekit.artifactoryonline.com/dronekit/libs-snapshot-local/"

--- a/src/main/scala/io/dronekit/request/Request.scala
+++ b/src/main/scala/io/dronekit/request/Request.scala
@@ -205,7 +205,7 @@ class Request(baseUri: String, client: Option[ESHttpClient] = None) {
   }
 
   def post(uri: String, params: Map[String, String] = Map(), oauth: Oauth=new Oauth("", ""), json: Boolean = true,
-           metrics: Map[String, String] = Map()): Future[HttpResponse] = {
+           metrics: Map[String, String] = Map(), body: Option[String] = None): Future[HttpResponse] = {
 
     var headers = List(RawHeader("Accept", "*/*"))
 
@@ -230,6 +230,10 @@ class Request(baseUri: String, client: Option[ESHttpClient] = None) {
         contentType = ContentType(MediaTypes.`application/x-www-form-urlencoded`, HttpCharsets.`UTF-8`),
         contentLength = paramStr.length,
         Source(List(paramStr)))
+    } else if (body.isDefined) {
+      val bodyStr = ByteString(body.get)
+      val cType = if (json) ContentTypes.`application/json` else ContentTypes.`text/plain(UTF-8)`
+      HttpEntity(contentType=cType, contentLength=bodyStr.length, Source(List(bodyStr)))
     } else {
       HttpEntity.Empty
     }


### PR DESCRIPTION
Quick and dirty to support posting arbitrary body strings instead of just maps.  Library needs some refactoring and cleaning p. bad though, will come back when I have time..  

Also having every test depend on external web services that we don't own seems pretty bad..